### PR TITLE
Add arm64 simulator

### DIFF
--- a/Sources/MBLDeviceModelHelper/Classes/UIDevice+Extension.swift
+++ b/Sources/MBLDeviceModelHelper/Classes/UIDevice+Extension.swift
@@ -21,6 +21,7 @@ var type: DeviceModelList {
 
         "i386"         :    .simulator,
         "x86_64"       :    .simulator,
+        "arm64"        :    .simulator,
         "iPhone1,1"    :    .iPhone,
         "iPhone1,2"    :    .iPhone3G,
         "iPhone2,1"    :    .iPhone3GS,


### PR DESCRIPTION
When you want to use MBLDeviceModelHelper with M1 processor Macs, `modelCode` is return arm64 for simulator. I added arm64 key with simulator value to DeviceModelList.